### PR TITLE
Update project progress board for v0.2.0

### DIFF
--- a/specs/UQRA_PROJECT_PROGRESS_BOARD.md
+++ b/specs/UQRA_PROJECT_PROGRESS_BOARD.md
@@ -10,16 +10,15 @@
 本文件用于追踪 UQRA 软件项目的当前任务、验收证据、阻塞条件和下一动作。项目范围、
 阶段定义和完成门槛以主计划为准；本看板不重新定义算法，也不管理论文正式规模实验。
 
-状态约定：
+### 1.1 状态标记
 
-| 状态 | 含义 | 更新条件 |
-| --- | --- | --- |
-| `DONE` | 已达到验收门并有证据 | 填写 commit、PR、测试、manifest 或报告链接 |
-| `IN_REVIEW` | 实现完成，正在远端审查或等待合并 | 关联开放 PR 和 required check |
-| `IN_PROGRESS` | 已开始且存在当前工作分支或产物 | 填写当前分支、负责人或最近证据 |
-| `READY` | 前置条件满足，可立即开始 | 下一动作必须明确且可执行 |
-| `BLOCKED` | 缺少外部资产、环境或裁决 | 写明阻塞条件和解除条件 |
-| `BACKLOG` | 已识别但尚未排期 | 说明依赖的前序任务 |
+| 标记 | 状态 | 含义 |
+|---|---|---|
+| ✅ | 已完成 | 交付物已形成，并达到本任务的验收标准 |
+| 🔄 | 进行中 | 当前正在处理，或下一步已经明确 |
+| ⏳ | 待开始 | 前置条件已满足，但尚未开展 |
+| ⛔ | 阻塞 | 缺少关键材料、用户决策或外部条件 |
+| ➖ | 不适用/取消 | 经决策不再纳入当前论文 |
 
 进度只按验收证据更新，不使用主观百分比。`paper_production`、论文表图和科学结论判定
 由独立论文仓库管理，不进入本看板。
@@ -28,48 +27,54 @@
 
 | 项目 | 当前值 | 状态/证据 |
 | --- | --- | --- |
-| 默认分支 | `master` | `v0.1.0` 已发布 |
-| 当前工作分支 | `codex/m0-m1-runner` | 工作树干净，已推送 |
-| 当前 PR | [#4 Complete M0/M1 runner governance and delivery contracts](https://github.com/Jinsongl/UQRA/pull/4) | `IN_REVIEW`，draft，merge state `CLEAN` |
-| Python 3.11 | `42 passed` | [CI run 30972248624](https://github.com/Jinsongl/UQRA/actions/runs/30972248624) |
-| Python 3.12 | `42 passed` | [CI run 30972248624](https://github.com/Jinsongl/UQRA/actions/runs/30972248624) |
-| Required check | `Adaptive compatibility gate` | 通过 |
-| 全新克隆验收 | Python 3.11.15，`42 passed`，smoke/full manifest 有效 | [`UQRA_V0.1.0_EVIDENCE.md`](releases/UQRA_V0.1.0_EVIDENCE.md) |
-| 下一建议版本 | `v0.2.0` | 等待 PR #4 合并后创建 |
+| 默认分支 | `master` | ✅ `v0.2.0` 已发布 |
+| 当前工作分支 | `codex/update-progress-board` | 🔄 更新项目看板 |
+| 最近 PR | [#4 Complete M0/M1 runner governance and delivery contracts](https://github.com/Jinsongl/UQRA/pull/4) | ✅ 已合并 |
+| Python 3.11 | `42 passed` | ✅ [CI run 30972668606](https://github.com/Jinsongl/UQRA/actions/runs/30972668606) |
+| Python 3.12 | `42 passed` | ✅ [CI run 30972668606](https://github.com/Jinsongl/UQRA/actions/runs/30972668606) |
+| Required check | `Adaptive compatibility gate` | ✅ 通过 |
+| 全新克隆验收 | Python 3.11.15，`42 passed`，smoke/full manifest 有效 | ✅ [`UQRA_V0.1.0_EVIDENCE.md`](releases/UQRA_V0.1.0_EVIDENCE.md) |
+| 当前 Release | [`v0.2.0`](https://github.com/Jinsongl/UQRA/releases/tag/v0.2.0) | ✅ 指向合并提交 `3445464d` |
+| 下一版本 | 待 M2 范围确定 | ⏳ 不提前承诺版本号 |
 
 ## 3. U0--U6 状态总览
 
 | 阶段 | 状态 | 当前结论 | 下一动作 |
 | --- | --- | --- | --- |
-| U0 治理冻结与证据清单 | `DONE` | 项目/论文边界、主计划、历史计划和交接接口已固化 | 随新裁决持续维护证据清单 |
-| U1 Legacy 基准恢复 | `BLOCKED` | 可恢复证据有限；历史候选池、测试集和 RNG/CV 状态缺失 | 执行 Legacy 环境审计并形成正式阻塞结论 |
-| U2 Modern 核心实现 | `DONE` | 核心算法完成，首个发布基线为 `v0.1.0` | 核心变更继续遵守裁决和回归门 |
-| U3 内核与逐轮行为回归 | `DONE`（可获得证据范围） | Phase 5--8 证据完整；历史 FourBranch trace 不可用 | 建立统一结案矩阵，与 U1 阻塞结论互链 |
-| U4 通用软件 benchmark | `IN_PROGRESS` | 二维 Hermite 缩减 benchmark 完成；多问题扩展未开始 | 启动 FourBranch reduced benchmark |
-| U5 Runner 发布门 | `DONE`（实现）/ `IN_REVIEW`（集成） | M1 schema、CLI、示例和 evidence 已完成并通过 CI | 合并 PR #4，发布 `v0.2.0` |
-| U6 版本化维护 | `IN_PROGRESS` | required CI 和版本化变更流程已建立 | 持续处理 benchmark、包装和依赖质量任务 |
+| U0 治理冻结与证据清单 | ✅ 已完成 | 项目/论文边界、主计划、历史计划和交接接口已固化 | 随新裁决持续维护证据清单 |
+| U1 Legacy 基准恢复 | ⛔ 阻塞 | 可恢复证据有限；历史候选池、测试集和 RNG/CV 状态缺失 | 执行 Legacy 环境审计并形成正式阻塞结论 |
+| U2 Modern 核心实现 | ✅ 已完成 | 核心算法完成，当前发布基线为 `v0.2.0` | 核心变更继续遵守裁决和回归门 |
+| U3 内核与逐轮行为回归 | ✅ 已完成（可获得证据范围） | Phase 5--8 证据完整；历史 FourBranch trace 不可用 | 建立统一结案矩阵，与 U1 阻塞结论互链 |
+| U4 通用软件 benchmark | 🔄 进行中 | 二维 Hermite 缩减 benchmark 完成；多问题扩展是当前主线 | 启动受控 benchmark registry/config v2 |
+| U5 Runner 发布门 | ✅ 已完成 | M1 schema、CLI、示例、evidence、PR #4 和 `v0.2.0` 发布均完成 | 按版本化流程维护后续交付 |
+| U6 版本化维护 | 🔄 进行中 | required CI 和版本化变更流程已建立 | 持续处理 benchmark、包装和依赖质量任务 |
 
 ## 4. 当前焦点
 
-### IN_REVIEW
+### ✅ 最近完成
 
 | ID | 优先级 | 任务 | 验收证据 | 下一动作 |
 | --- | --- | --- | --- | --- |
-| REL-01 | P0 | 合并 M0/M1 交付 | PR #4；Python 3.11/3.12 和聚合 gate 全部通过 | 将 PR 转为 ready，复核后合并到 `master` |
+| REL-01 | P0 | 合并 M0/M1 交付 | PR #4；Python 3.11/3.12 和聚合 gate 全部通过 | ✅ 已合并到 `master` |
+| REL-02 | P0 | 发布 `v0.2.0` | tag、GitHub Release、required gate | ✅ 已发布 |
 
-### READY
+### 🔄 进行中
 
 | ID | 优先级 | 任务 | 前置条件 | 完成门 |
 | --- | --- | --- | --- | --- |
-| REL-02 | P0 | 发布 `v0.2.0` | REL-01 合并 | tag、GitHub Release、更新后的 evidence package 和 clean-clone smoke 均完成 |
-| BENCH-01 | P1 | 设计受控 benchmark registry/config v2 | REL-01 合并 | 禁止任意 Python 导入；配置能选择已注册 benchmark 并通过 schema 校验 |
+| BENCH-01 | P1 | 设计受控 benchmark registry/config v2 | `v0.2.0` 已发布 | 禁止任意 Python 导入；配置能选择已注册 benchmark 并通过 schema 校验 |
+
+### ⏳ 待开始
+
+| ID | 优先级 | 任务 | 前置条件 | 完成门 |
+| --- | --- | --- | --- | --- |
 | BENCH-02 | P1 | FourBranch reduced benchmark | BENCH-01 | 固定输入/seed/hash、DoI 路径、manifest、trace 和重复性测试通过 |
 | LEG-01 | P1 | Legacy Python 3.8/3.9 环境审计 | 无 | 依赖、可运行入口和失败类型形成可审计报告 |
 | REG-01 | P1 | U3 行为回归结案矩阵 | LEG-01 可并行 | 已验证项与 `unavailable` 项逐项对应证据，无状态歧义 |
 
 ## 5. 后续队列
 
-### BACKLOG：U4 benchmark 扩展
+### ⏳ 待开始：U4 benchmark 扩展
 
 | ID | 优先级 | 任务 | 主要保护行为 | 依赖 |
 | --- | --- | --- | --- | --- |
@@ -87,7 +92,7 @@
 - 预算、预期状态、`stop_reason` 和 trace hash/容差；
 - 明确禁止 `paper_production` 声明。
 
-### BACKLOG：包装与跨环境质量
+### ⏳ 待开始：包装与跨环境质量
 
 | ID | 优先级 | 任务 | 完成门 |
 | --- | --- | --- | --- |
@@ -98,7 +103,7 @@
 | CI-01 | P2 | 扩展 Windows/Linux CI | Python 3.11/3.12 在支持平台通过 |
 | SCHEMA-01 | P2 | 增加标准 JSON Schema 验证器测试 | 示例和生成 manifest 同时通过运行时与标准 schema 校验 |
 
-### BLOCKED：历史资产
+### ⛔ 阻塞：历史资产
 
 | ID | 阻塞项 | 已有证据 | 解除或关闭条件 |
 | --- | --- | --- | --- |
@@ -109,22 +114,23 @@
 
 | 里程碑 | 状态 | 主要证据 |
 | --- | --- | --- |
-| Phase 5--11 自适应实现与资格验证 | `DONE` | `ADAPTIVE_PCE_PHASE*_SUMMARY`、冻结 manifest |
-| `v0.1.0` 软件基线 | `DONE` | PR #3、tag `v0.1.0`、required gate |
-| M0 项目治理与边界 | `DONE` | commit `9ee5ed6` |
-| M1 schema、CLI 与示例 | `DONE` | commit `c6fea07`；42 项兼容性测试 |
-| M1 evidence 与 clean-clone 验收 | `DONE` | commit `c69032d`；`specs/releases/` |
-| UQRA-MV1 | `DONE` | U5 交付门和 evidence package |
+| Phase 5--11 自适应实现与资格验证 | ✅ 已完成 | `ADAPTIVE_PCE_PHASE*_SUMMARY`、冻结 manifest |
+| `v0.1.0` 软件基线 | ✅ 已完成 | PR #3、tag `v0.1.0`、required gate |
+| M0 项目治理与边界 | ✅ 已完成 | commit `9ee5ed6` |
+| M1 schema、CLI 与示例 | ✅ 已完成 | commit `c6fea07`；42 项兼容性测试 |
+| M1 evidence 与 clean-clone 验收 | ✅ 已完成 | commit `c69032d`；`specs/releases/` |
+| UQRA-MV1 | ✅ 已完成 | U5 交付门和 evidence package |
+| `v0.2.0` runner contracts release | ✅ 已完成 | PR #4、merge `3445464d`、GitHub Release |
 
 ## 7. 更新流程
 
 每次开始或完成任务时按以下顺序更新：
 
 1. 为任务分配稳定 ID，不复用已关闭 ID；
-2. 从 `BACKLOG`/`READY` 移到 `IN_PROGRESS` 时，填写分支或第一项产物；
-3. 进入 `IN_REVIEW` 时，填写 PR 和 CI 链接；
-4. 只有验收门全部满足后才能标记 `DONE`；
-5. `BLOCKED` 必须写明外部依赖、已有证据和关闭条件；
+2. 从 `⏳ 待开始` 移到 `🔄 进行中` 时，填写分支或第一项产物；
+3. 远端审查仍使用 `🔄 进行中`，并填写 PR 和 CI 链接；
+4. 只有验收门全部满足后才能标记 `✅ 已完成`；
+5. `⛔ 阻塞` 必须写明外部依赖、已有证据和关闭条件；
 6. 更新顶部状态日期、U0--U6 总览和当前焦点；
 7. 若任务改变项目范围或算法契约，先更新主计划或兼容性裁决，再更新看板；
 8. 同步更新相关 evidence、summary 和 release 文档，不在看板复制大段实验结果。


### PR DESCRIPTION
## Summary

- normalize progress-board status markers and definitions
- record the merged PR #4 and published v0.2.0 release
- refresh milestone and next-work states so the board remains the current project status entry

## Validation

- `git diff --check`
- documentation-only change; Adaptive compatibility gate will run in CI
