### PR TITLE
Add M2.1 benchmark registry contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,14 @@ benchmark configurations use the v2 static registry contract:
 ```bash
 python -m uqra.adaptive.run --config examples/configs/adaptive_registry_v2_smoke.json
 python -m uqra.adaptive.run --config examples/configs/adaptive_registry_v2_full.json
+python -m uqra.adaptive.run --config examples/configs/four_branch_reduced_v1.json
 ```
 
 The v2 `runner.benchmark` value must be a name published by UQRA's static
 registry. Python module paths and configuration-driven imports are not accepted.
+`four_branch_reduced_v1` is a newly generated reduced software fixture with
+separate frozen candidate, test, and reference streams; it is not a replay of
+the unavailable historical FourBranch datasets.
 
 The v1/v2 configuration, runner-manifest, and trace contracts are published under
 [`schemas/`](schemas/). This entry point intentionally accepts only

--- a/README.md
+++ b/README.md
@@ -40,7 +40,18 @@ python -m uqra.adaptive.run --config examples/configs/adaptive_reduced_smoke.jso
 python -m uqra.adaptive.run --config examples/configs/adaptive_reduced_full.json
 ```
 
-The configuration, runner-manifest, and trace contracts are published under
+The v1 examples above remain supported for the `v0.2.0` delivery contract. New
+benchmark configurations use the v2 static registry contract:
+
+```bash
+python -m uqra.adaptive.run --config examples/configs/adaptive_registry_v2_smoke.json
+python -m uqra.adaptive.run --config examples/configs/adaptive_registry_v2_full.json
+```
+
+The v2 `runner.benchmark` value must be a name published by UQRA's static
+registry. Python module paths and configuration-driven imports are not accepted.
+
+The v1/v2 configuration, runner-manifest, and trace contracts are published under
 [`schemas/`](schemas/). This entry point intentionally accepts only
 `purpose: software_benchmark` and `scale: reduced`; formal paper-production
 experiments belong to the independent paper repository.

--- a/examples/configs/adaptive_registry_v2_full.json
+++ b/examples/configs/adaptive_registry_v2_full.json
@@ -1,0 +1,13 @@
+{
+  "schema": "uqra.adaptive.runner-config/v2",
+  "purpose": "software_benchmark",
+  "scale": "reduced",
+  "runner": {
+    "kind": "deterministic_benchmark",
+    "benchmark": "phase8_two_dimensional_hermite",
+    "scenarios": ["converged", "max_order", "overfit_fallback", "runtime_failure"]
+  },
+  "output": {
+    "manifest": "artifacts/examples/adaptive_registry_v2_full_manifest.json"
+  }
+}

--- a/examples/configs/adaptive_registry_v2_smoke.json
+++ b/examples/configs/adaptive_registry_v2_smoke.json
@@ -1,0 +1,13 @@
+{
+  "schema": "uqra.adaptive.runner-config/v2",
+  "purpose": "software_benchmark",
+  "scale": "reduced",
+  "runner": {
+    "kind": "deterministic_benchmark",
+    "benchmark": "phase8_two_dimensional_hermite",
+    "scenarios": ["converged"]
+  },
+  "output": {
+    "manifest": "artifacts/examples/adaptive_registry_v2_smoke_manifest.json"
+  }
+}

--- a/examples/configs/four_branch_reduced_v1.json
+++ b/examples/configs/four_branch_reduced_v1.json
@@ -1,0 +1,13 @@
+{
+  "schema": "uqra.adaptive.runner-config/v2",
+  "purpose": "software_benchmark",
+  "scale": "reduced",
+  "runner": {
+    "kind": "deterministic_benchmark",
+    "benchmark": "four_branch_reduced_v1",
+    "scenarios": ["reduced"]
+  },
+  "output": {
+    "manifest": "artifacts/examples/four_branch_reduced_v1_manifest.json"
+  }
+}

--- a/schemas/adaptive-runner-config-v2.schema.json
+++ b/schemas/adaptive-runner-config-v2.schema.json
@@ -15,13 +15,13 @@
       "required": ["kind", "benchmark", "scenarios"],
       "properties": {
         "kind": {"const": "deterministic_benchmark"},
-        "benchmark": {"enum": ["phase8_two_dimensional_hermite"]},
+        "benchmark": {"enum": ["four_branch_reduced_v1", "phase8_two_dimensional_hermite"]},
         "scenarios": {
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
           "items": {
-            "enum": ["converged", "max_order", "overfit_fallback", "runtime_failure"]
+            "enum": ["converged", "max_order", "overfit_fallback", "reduced", "runtime_failure"]
           }
         }
       }

--- a/schemas/adaptive-runner-config-v2.schema.json
+++ b/schemas/adaptive-runner-config-v2.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Jinsongl/UQRA/schemas/adaptive-runner-config-v2.schema.json",
+  "title": "UQRA adaptive runner configuration v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "purpose", "scale", "runner", "output"],
+  "properties": {
+    "schema": {"const": "uqra.adaptive.runner-config/v2"},
+    "purpose": {"const": "software_benchmark"},
+    "scale": {"const": "reduced"},
+    "runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "benchmark", "scenarios"],
+      "properties": {
+        "kind": {"const": "deterministic_benchmark"},
+        "benchmark": {"enum": ["phase8_two_dimensional_hermite"]},
+        "scenarios": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["converged", "max_order", "overfit_fallback", "runtime_failure"]
+          }
+        }
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["manifest"],
+      "properties": {"manifest": {"type": "string", "minLength": 1}}
+    }
+  }
+}

--- a/specs/UQRA_PROJECT_DEVELOPMENT_PLAN.md
+++ b/specs/UQRA_PROJECT_DEVELOPMENT_PLAN.md
@@ -3,7 +3,7 @@
 状态：执行中  
 版本：2026-08-05 split-plan v2  
 项目仓库：`https://github.com/Jinsongl/UQRA`  
-当前发布基线：`v0.1.0`
+当前发布基线：`v0.2.0`
 
 执行进度、当前 PR、阻塞项和下一动作由
 `specs/UQRA_PROJECT_PROGRESS_BOARD.md` 维护；本文件只定义项目范围、阶段和验收门。
@@ -147,7 +147,26 @@ Python 3.12.13 完整兼容性套件亦为 `42 passed`。交付证据见
 - canonical 源码始终保持冻结；
 - portable runner 不进入 UQRA 生产实现。
 
-## 4. 向论文项目交付的唯一接口
+## 4. 交付里程碑与任务编号
+
+`U0--U6` 表示长期工作流，不随单次发布关闭；`M0--M3` 表示可验收的交付
+里程碑；`BENCH-*`、`LEG-*`、`REG-*`、`PKG-*`、`CI-*` 和 `SCHEMA-*`
+表示看板中的具体任务。任务 ID 不替代里程碑编号，每项任务必须在看板中标明所属
+里程碑或持续工作流。
+
+| 里程碑 | 状态 | 范围 | 完成门 |
+| --- | --- | --- | --- |
+| M0 治理与边界 | 已完成 | 主计划、项目/论文边界、兼容性裁决和证据清单 | 计划与边界进入版本控制 |
+| M1 Runner 契约与可审计发布（历史称 UQRA-MV1） | 已完成 | config/manifest/trace schema、CLI、两个示例、evidence package、clean-clone 验收 | Python 3.11/3.12、required CI、发布证据和正式版本全部通过；对应 `v0.2.0` |
+| M2.1 Benchmark 注册与配置契约 | 进行中 | 受控 benchmark registry、config v2 和 schema；对应 `BENCH-01` | 配置只能选择已注册 benchmark，禁止任意 Python 导入，并通过 schema 与回归测试 |
+| M2.2 首个多路径缩减基准 | 待开始 | FourBranch reduced；对应 `BENCH-02` | 固定输入、seed、数据 hash、DoI 路径、manifest、trace 和重复性测试通过 |
+| M2.3 多问题 Benchmark 验收 | 待开始 | `BENCH-03--06` | 至少三个不同性质的缩减 benchmark 通过统一 schema、CI 和声明边界验收 |
+| M3 包装与跨环境质量 | 待开始 | `PKG-*`、`CI-*`、`SCHEMA-*` | wheel/sdist、版本源、标准 schema 校验和支持平台 CI 达到发布门 |
+
+`LEG-*` 和 `REG-*` 属于 U1/U3 的证据闭环任务，不并入 M2 benchmark 交付，也不
+因 M2 完成而自动关闭。
+
+## 5. 向论文项目交付的唯一接口
 
 每次正式交付必须是不可含混的证据包，至少包含：
 
@@ -162,19 +181,20 @@ Python 3.12.13 完整兼容性套件亦为 `42 passed`。交付证据见
 
 论文仓库不得复制 `uqra/adaptive` 后形成第二套正式算法。需要算法变更时，回到本项目完成裁决、实现、测试和新版本交付。
 
-## 5. 当前最小下一目标
+## 6. 当前最小下一目标
 
-**UQRA-MV1：已完成。**
+**M1 Runner 契约与可审计发布：已完成。** 历史文档中的 `UQRA-MV1` 与 M1
+是同一里程碑，不再作为独立编号使用。
 
 完成证据：固定 tag/commit、干净环境命令、版本化 schema、两个配置模板、完整
 manifest、Python 3.11/3.12 的 42 项兼容性测试、全新克隆验收、确定性回归结果和
 已知限制均已进入 evidence package。论文项目是否拥有 FourBranch 等算例资产不
 阻塞 UQRA 通用功能发布，但不得用软件回归结果冒充论文算例复现。
 
-下一最小目标转为 U4 通用软件 benchmark 扩展与 U6 持续维护；新增正式发布应使用
-新版本号，不得静默覆盖 `v0.1.0`。
+当前最小目标为 **M2.1 Benchmark 注册与配置契约**，对应看板任务 `BENCH-01`。
+M2.1 完成后才启动 M2.2；新增正式发布应使用新版本号，不得静默覆盖 `v0.2.0`。
 
-## 6. 历史文档关系
+## 7. 历史文档关系
 
 - `ADAPTIVE_PCE_DEVELOPMENT_PLAN.md`：既有阶段 5–11 的详细开发记录；
 - `DISSERTATION_NUMERICAL_REPRODUCTION_PLAN.md`：指向独立论文仓库完整复现计划的交接接口，本仓库不再管理 R0--R7；

--- a/specs/UQRA_PROJECT_DEVELOPMENT_PLAN.md
+++ b/specs/UQRA_PROJECT_DEVELOPMENT_PLAN.md
@@ -158,8 +158,8 @@ Python 3.12.13 完整兼容性套件亦为 `42 passed`。交付证据见
 | --- | --- | --- | --- |
 | M0 治理与边界 | 已完成 | 主计划、项目/论文边界、兼容性裁决和证据清单 | 计划与边界进入版本控制 |
 | M1 Runner 契约与可审计发布（历史称 UQRA-MV1） | 已完成 | config/manifest/trace schema、CLI、两个示例、evidence package、clean-clone 验收 | Python 3.11/3.12、required CI、发布证据和正式版本全部通过；对应 `v0.2.0` |
-| M2.1 Benchmark 注册与配置契约 | 进行中 | 受控 benchmark registry、config v2 和 schema；对应 `BENCH-01` | 配置只能选择已注册 benchmark，禁止任意 Python 导入，并通过 schema 与回归测试 |
-| M2.2 首个多路径缩减基准 | 待开始 | FourBranch reduced；对应 `BENCH-02` | 固定输入、seed、数据 hash、DoI 路径、manifest、trace 和重复性测试通过 |
+| M2.1 Benchmark 注册与配置契约 | 已完成 | 受控 benchmark registry、config v2 和 schema；对应 `BENCH-01` | 配置只能选择已注册 benchmark，禁止任意 Python 导入；PR #6 双版本 45 项兼容性测试和 required gate 通过 |
+| M2.2 首个多路径缩减基准 | 进行中 | FourBranch reduced；对应 `BENCH-02` | 固定输入、seed、数据 hash、DoI 路径、manifest、trace 和重复性测试通过 |
 | M2.3 多问题 Benchmark 验收 | 待开始 | `BENCH-03--06` | 至少三个不同性质的缩减 benchmark 通过统一 schema、CI 和声明边界验收 |
 | M3 包装与跨环境质量 | 待开始 | `PKG-*`、`CI-*`、`SCHEMA-*` | wheel/sdist、版本源、标准 schema 校验和支持平台 CI 达到发布门 |
 
@@ -191,8 +191,9 @@ manifest、Python 3.11/3.12 的 42 项兼容性测试、全新克隆验收、确
 已知限制均已进入 evidence package。论文项目是否拥有 FourBranch 等算例资产不
 阻塞 UQRA 通用功能发布，但不得用软件回归结果冒充论文算例复现。
 
-当前最小目标为 **M2.1 Benchmark 注册与配置契约**，对应看板任务 `BENCH-01`。
-M2.1 完成后才启动 M2.2；新增正式发布应使用新版本号，不得静默覆盖 `v0.2.0`。
+当前最小目标为 **M2.2 首个多路径缩减基准**，对应看板任务 `BENCH-02`。
+M2.2 使用注册表中的 FourBranch reduced 配置验证输入身份、DoI 路径、manifest、
+trace 和重复性；新增正式发布应使用新版本号，不得静默覆盖 `v0.2.0`。
 
 ## 7. 历史文档关系
 

--- a/specs/UQRA_PROJECT_DEVELOPMENT_PLAN.md
+++ b/specs/UQRA_PROJECT_DEVELOPMENT_PLAN.md
@@ -159,7 +159,7 @@ Python 3.12.13 完整兼容性套件亦为 `42 passed`。交付证据见
 | M0 治理与边界 | 已完成 | 主计划、项目/论文边界、兼容性裁决和证据清单 | 计划与边界进入版本控制 |
 | M1 Runner 契约与可审计发布（历史称 UQRA-MV1） | 已完成 | config/manifest/trace schema、CLI、两个示例、evidence package、clean-clone 验收 | Python 3.11/3.12、required CI、发布证据和正式版本全部通过；对应 `v0.2.0` |
 | M2.1 Benchmark 注册与配置契约 | 已完成 | 受控 benchmark registry、config v2 和 schema；对应 `BENCH-01` | 配置只能选择已注册 benchmark，禁止任意 Python 导入；PR #6 双版本 45 项兼容性测试和 required gate 通过 |
-| M2.2 首个多路径缩减基准 | 进行中 | FourBranch reduced；对应 `BENCH-02` | 固定输入、seed、数据 hash、DoI 路径、manifest、trace 和重复性测试通过 |
+| M2.2 首个多路径缩减基准 | 已完成 | FourBranch reduced；对应 `BENCH-02` | 固定输入、seed、数据 hash、DoI 路径、manifest、trace、重复性测试和 PR #6 required gate 通过 |
 | M2.3 多问题 Benchmark 验收 | 待开始 | `BENCH-03--06` | 至少三个不同性质的缩减 benchmark 通过统一 schema、CI 和声明边界验收 |
 | M3 包装与跨环境质量 | 待开始 | `PKG-*`、`CI-*`、`SCHEMA-*` | wheel/sdist、版本源、标准 schema 校验和支持平台 CI 达到发布门 |
 
@@ -191,9 +191,9 @@ manifest、Python 3.11/3.12 的 42 项兼容性测试、全新克隆验收、确
 已知限制均已进入 evidence package。论文项目是否拥有 FourBranch 等算例资产不
 阻塞 UQRA 通用功能发布，但不得用软件回归结果冒充论文算例复现。
 
-当前最小目标为 **M2.2 首个多路径缩减基准**，对应看板任务 `BENCH-02`。
-M2.2 使用注册表中的 FourBranch reduced 配置验证输入身份、DoI 路径、manifest、
-trace 和重复性；新增正式发布应使用新版本号，不得静默覆盖 `v0.2.0`。
+M2.2 已完成；`four_branch_reduced_v1` 使用三套独立冻结数据流，并明确不是历史
+FourBranch replay。下一最小目标为 **M2.3 多问题 Benchmark 验收**，但须先在看板
+启动具体 `BENCH-03--05` 任务；新增正式发布应使用新版本号，不得静默覆盖 `v0.2.0`。
 
 ## 7. 历史文档关系
 

--- a/specs/UQRA_PROJECT_PROGRESS_BOARD.md
+++ b/specs/UQRA_PROJECT_PROGRESS_BOARD.md
@@ -28,16 +28,34 @@
 | 项目 | 当前值 | 状态/证据 |
 | --- | --- | --- |
 | 默认分支 | `master` | ✅ `v0.2.0` 已发布 |
-| 当前工作分支 | `codex/update-progress-board` | 🔄 更新项目看板 |
-| 最近 PR | [#4 Complete M0/M1 runner governance and delivery contracts](https://github.com/Jinsongl/UQRA/pull/4) | ✅ 已合并 |
+| 当前工作分支 | `codex/normalize-roadmap-numbering` | 🔄 统一里程碑与任务编号 |
+| 最近 PR | [#5 Update project progress board for v0.2.0](https://github.com/Jinsongl/UQRA/pull/5) | ✅ 已合并 |
 | Python 3.11 | `42 passed` | ✅ [CI run 30972668606](https://github.com/Jinsongl/UQRA/actions/runs/30972668606) |
 | Python 3.12 | `42 passed` | ✅ [CI run 30972668606](https://github.com/Jinsongl/UQRA/actions/runs/30972668606) |
 | Required check | `Adaptive compatibility gate` | ✅ 通过 |
 | 全新克隆验收 | Python 3.11.15，`42 passed`，smoke/full manifest 有效 | ✅ [`UQRA_V0.1.0_EVIDENCE.md`](releases/UQRA_V0.1.0_EVIDENCE.md) |
 | 当前 Release | [`v0.2.0`](https://github.com/Jinsongl/UQRA/releases/tag/v0.2.0) | ✅ 指向合并提交 `3445464d` |
-| 下一版本 | 待 M2 范围确定 | ⏳ 不提前承诺版本号 |
+| 下一版本 | 待 M2.1--M2.3 完成范围确定 | ⏳ 不提前承诺版本号 |
 
-## 3. U0--U6 状态总览
+## 3. 编号体系与里程碑路线
+
+- `U0--U6`：长期工作流，用于表达项目责任边界和持续状态；
+- `M0--M3`：交付里程碑，用于表达可验收的阶段成果；
+- `BENCH/LEG/REG/PKG/CI/SCHEMA-*`：具体任务 ID，用于分支、PR、CI 和证据追踪。
+
+| 里程碑 | 状态 | 所属工作流 | 任务映射 | 完成门摘要 |
+| --- | --- | --- | --- | --- |
+| M0 治理与边界 | ✅ 已完成 | U0 | 计划与边界文档 | 进入版本控制并明确项目/论文边界 |
+| M1 Runner 契约与可审计发布（原 UQRA-MV1） | ✅ 已完成 | U5、U6 | schema、CLI、示例、evidence、clean-clone、REL-01/02 | `v0.2.0`、双版本 CI 和 required gate 通过 |
+| M2.1 Benchmark 注册与配置契约 | 🔄 进行中 | U4、U6 | BENCH-01 | 本地实现与双版本 45 项测试通过；待远端 CI/审查 |
+| M2.2 首个多路径缩减基准 | ⏳ 待开始 | U4 | BENCH-02 | FourBranch reduced 的输入身份、trace 与重复性证据完整 |
+| M2.3 多问题 Benchmark 验收 | ⏳ 待开始 | U4 | BENCH-03--06 | 至少三个不同性质 benchmark 通过统一验收 |
+| M3 包装与跨环境质量 | ⏳ 待开始 | U6 | PKG-01--04、CI-01、SCHEMA-01 | 包装、版本源、schema 验证和跨平台 CI 达到发布门 |
+
+`LEG-01/02` 与 `REG-01/02` 是 U1/U3 的证据闭环任务，不属于 M2，也不因 M2 完成
+而自动关闭。
+
+## 4. U0--U6 状态总览
 
 | 阶段 | 状态 | 当前结论 | 下一动作 |
 | --- | --- | --- | --- |
@@ -49,39 +67,39 @@
 | U5 Runner 发布门 | ✅ 已完成 | M1 schema、CLI、示例、evidence、PR #4 和 `v0.2.0` 发布均完成 | 按版本化流程维护后续交付 |
 | U6 版本化维护 | 🔄 进行中 | required CI 和版本化变更流程已建立 | 持续处理 benchmark、包装和依赖质量任务 |
 
-## 4. 当前焦点
+## 5. 当前焦点
 
 ### ✅ 最近完成
 
-| ID | 优先级 | 任务 | 验收证据 | 下一动作 |
+| ID | 归属 / 优先级 | 任务 | 验收证据 | 下一动作 |
 | --- | --- | --- | --- | --- |
-| REL-01 | P0 | 合并 M0/M1 交付 | PR #4；Python 3.11/3.12 和聚合 gate 全部通过 | ✅ 已合并到 `master` |
-| REL-02 | P0 | 发布 `v0.2.0` | tag、GitHub Release、required gate | ✅ 已发布 |
+| REL-01 | M0/M1 / P0 | 合并 M0/M1 交付 | PR #4；Python 3.11/3.12 和聚合 gate 全部通过 | ✅ 已合并到 `master` |
+| REL-02 | M1 / P0 | 发布 `v0.2.0` | tag、GitHub Release、required gate | ✅ 已发布 |
 
 ### 🔄 进行中
 
-| ID | 优先级 | 任务 | 前置条件 | 完成门 |
+| ID | 归属 / 优先级 | 任务 | 当前证据 | 完成门 |
 | --- | --- | --- | --- | --- |
-| BENCH-01 | P1 | 设计受控 benchmark registry/config v2 | `v0.2.0` 已发布 | 禁止任意 Python 导入；配置能选择已注册 benchmark 并通过 schema 校验 |
+| BENCH-01 | M2.1 / P1 | 设计受控 benchmark registry/config v2 | 静态 registry、v2 schema、两个示例；Python 3.11/3.12 均 `45 passed` | 禁止任意 Python 导入；配置能选择已注册 benchmark；远端 CI 和审查通过 |
 
 ### ⏳ 待开始
 
-| ID | 优先级 | 任务 | 前置条件 | 完成门 |
+| ID | 归属 / 优先级 | 任务 | 前置条件 | 完成门 |
 | --- | --- | --- | --- | --- |
-| BENCH-02 | P1 | FourBranch reduced benchmark | BENCH-01 | 固定输入/seed/hash、DoI 路径、manifest、trace 和重复性测试通过 |
-| LEG-01 | P1 | Legacy Python 3.8/3.9 环境审计 | 无 | 依赖、可运行入口和失败类型形成可审计报告 |
-| REG-01 | P1 | U3 行为回归结案矩阵 | LEG-01 可并行 | 已验证项与 `unavailable` 项逐项对应证据，无状态歧义 |
+| BENCH-02 | M2.2 / P1 | FourBranch reduced benchmark | BENCH-01 | 固定输入/seed/hash、DoI 路径、manifest、trace 和重复性测试通过 |
+| LEG-01 | U1 / P1 | Legacy Python 3.8/3.9 环境审计 | 无 | 依赖、可运行入口和失败类型形成可审计报告 |
+| REG-01 | U3 / P1 | U3 行为回归结案矩阵 | LEG-01 可并行 | 已验证项与 `unavailable` 项逐项对应证据，无状态歧义 |
 
-## 5. 后续队列
+## 6. 后续队列
 
 ### ⏳ 待开始：U4 benchmark 扩展
 
-| ID | 优先级 | 任务 | 主要保护行为 | 依赖 |
+| ID | 归属 / 优先级 | 任务 | 主要保护行为 | 依赖 |
 | --- | --- | --- | --- | --- |
-| BENCH-03 | P1 | Ishigami reduced | 非线性和交互项 | BENCH-01 |
-| BENCH-04 | P1 | Gayton reduced | 可靠性函数和局部失效域 | BENCH-01 |
-| BENCH-05 | P1 | Damped oscillator reduced | 动态模型接口和高成本模型替身 | BENCH-01 |
-| BENCH-06 | P1 | U4 多问题验收 | 至少三个不同性质 benchmark、schema、CI 和声明边界 | BENCH-02--05 中至少三个完成 |
+| BENCH-03 | M2.3 / P1 | Ishigami reduced | 非线性和交互项 | BENCH-01 |
+| BENCH-04 | M2.3 / P1 | Gayton reduced | 可靠性函数和局部失效域 | BENCH-01 |
+| BENCH-05 | M2.3 / P1 | Damped oscillator reduced | 动态模型接口和高成本模型替身 | BENCH-01 |
+| BENCH-06 | M2.3 / P1 | U4 多问题验收 | 至少三个不同性质 benchmark、schema、CI 和声明边界 | BENCH-02--05 中至少三个完成 |
 
 每个 benchmark 必须记录：
 
@@ -94,14 +112,14 @@
 
 ### ⏳ 待开始：包装与跨环境质量
 
-| ID | 优先级 | 任务 | 完成门 |
+| ID | 归属 / 优先级 | 任务 | 完成门 |
 | --- | --- | --- | --- |
-| PKG-01 | P2 | 构建并测试 sdist/wheel | 从仓库外安装、导入和运行 CLI 成功 |
-| PKG-02 | P2 | 将主要元数据迁移到 `pyproject.toml` | 不再依赖旧 `setup.py upload` 发布逻辑 |
-| PKG-03 | P2 | 建立 `uqra.__version__` 唯一版本源 | 包、CLI、manifest 版本一致 |
-| PKG-04 | P2 | 清理 Python 3.12 转义警告 | 兼容性测试无对应 SyntaxWarning/DeprecationWarning |
-| CI-01 | P2 | 扩展 Windows/Linux CI | Python 3.11/3.12 在支持平台通过 |
-| SCHEMA-01 | P2 | 增加标准 JSON Schema 验证器测试 | 示例和生成 manifest 同时通过运行时与标准 schema 校验 |
+| PKG-01 | M3 / P2 | 构建并测试 sdist/wheel | 从仓库外安装、导入和运行 CLI 成功 |
+| PKG-02 | M3 / P2 | 将主要元数据迁移到 `pyproject.toml` | 不再依赖旧 `setup.py upload` 发布逻辑 |
+| PKG-03 | M3 / P2 | 建立 `uqra.__version__` 唯一版本源 | 包、CLI、manifest 版本一致 |
+| PKG-04 | M3 / P2 | 清理 Python 3.12 转义警告 | 兼容性测试无对应 SyntaxWarning/DeprecationWarning |
+| CI-01 | M3 / P2 | 扩展 Windows/Linux CI | Python 3.11/3.12 在支持平台通过 |
+| SCHEMA-01 | M3 / P2 | 增加标准 JSON Schema 验证器测试 | 示例和生成 manifest 同时通过运行时与标准 schema 校验 |
 
 ### ⛔ 阻塞：历史资产
 
@@ -110,23 +128,21 @@
 | LEG-02 | 完整历史 FourBranch replay | Phase 9 inventory 与 IDX-01/IDX-02 诊断 | 找回原候选池、测试集、逐轮输出和 RNG/CV 状态，或正式结案为永久 `unavailable` |
 | REG-02 | 完整历史逐轮 trace 等价 | U3 可获得证据范围已完成 | 依赖 LEG-02；不得以最终 Pf 接近替代 |
 
-## 6. 已完成里程碑
+## 7. 已完成里程碑
 
 | 里程碑 | 状态 | 主要证据 |
 | --- | --- | --- |
 | Phase 5--11 自适应实现与资格验证 | ✅ 已完成 | `ADAPTIVE_PCE_PHASE*_SUMMARY`、冻结 manifest |
 | `v0.1.0` 软件基线 | ✅ 已完成 | PR #3、tag `v0.1.0`、required gate |
 | M0 项目治理与边界 | ✅ 已完成 | commit `9ee5ed6` |
-| M1 schema、CLI 与示例 | ✅ 已完成 | commit `c6fea07`；42 项兼容性测试 |
-| M1 evidence 与 clean-clone 验收 | ✅ 已完成 | commit `c69032d`；`specs/releases/` |
-| UQRA-MV1 | ✅ 已完成 | U5 交付门和 evidence package |
+| M1 Runner 契约与可审计发布（原 UQRA-MV1） | ✅ 已完成 | commits `c6fea07`、`c69032d`；42 项兼容性测试；U5 交付门和 `specs/releases/` |
 | `v0.2.0` runner contracts release | ✅ 已完成 | PR #4、merge `3445464d`、GitHub Release |
 
-## 7. 更新流程
+## 8. 更新流程
 
 每次开始或完成任务时按以下顺序更新：
 
-1. 为任务分配稳定 ID，不复用已关闭 ID；
+1. 为任务分配稳定 ID，并标明所属 `M*` 里程碑或 `U*` 持续工作流；不复用已关闭 ID；
 2. 从 `⏳ 待开始` 移到 `🔄 进行中` 时，填写分支或第一项产物；
 3. 远端审查仍使用 `🔄 进行中`，并填写 PR 和 CI 链接；
 4. 只有验收门全部满足后才能标记 `✅ 已完成`；
@@ -135,7 +151,7 @@
 7. 若任务改变项目范围或算法契约，先更新主计划或兼容性裁决，再更新看板；
 8. 同步更新相关 evidence、summary 和 release 文档，不在看板复制大段实验结果。
 
-## 8. 不进入本看板的工作
+## 9. 不进入本看板的工作
 
 - 正式规模 FourBranch 重复实验；
 - PEM/Structural Safety 论文修改；

--- a/specs/UQRA_PROJECT_PROGRESS_BOARD.md
+++ b/specs/UQRA_PROJECT_PROGRESS_BOARD.md
@@ -30,8 +30,8 @@
 | 默认分支 | `master` | ✅ `v0.2.0` 已发布 |
 | 当前工作分支 | `codex/normalize-roadmap-numbering` | 🔄 统一里程碑与任务编号 |
 | 最近 PR | [#6 Add M2.1 benchmark registry contract](https://github.com/Jinsongl/UQRA/pull/6) | 🔄 Draft；CI 已通过 |
-| Python 3.11 | `45 passed` | ✅ [CI run 30978105375](https://github.com/Jinsongl/UQRA/actions/runs/30978105375) |
-| Python 3.12 | `45 passed` | ✅ [CI run 30978105375](https://github.com/Jinsongl/UQRA/actions/runs/30978105375) |
+| Python 3.11 | `47 passed` | ✅ [PR #6 checks](https://github.com/Jinsongl/UQRA/pull/6/checks) |
+| Python 3.12 | `47 passed` | ✅ [PR #6 checks](https://github.com/Jinsongl/UQRA/pull/6/checks) |
 | Required check | `Adaptive compatibility gate` | ✅ 通过 |
 | 全新克隆验收 | Python 3.11.15，`42 passed`，smoke/full manifest 有效 | ✅ [`UQRA_V0.1.0_EVIDENCE.md`](releases/UQRA_V0.1.0_EVIDENCE.md) |
 | 当前 Release | [`v0.2.0`](https://github.com/Jinsongl/UQRA/releases/tag/v0.2.0) | ✅ 指向合并提交 `3445464d` |
@@ -48,7 +48,7 @@
 | M0 治理与边界 | ✅ 已完成 | U0 | 计划与边界文档 | 进入版本控制并明确项目/论文边界 |
 | M1 Runner 契约与可审计发布（原 UQRA-MV1） | ✅ 已完成 | U5、U6 | schema、CLI、示例、evidence、clean-clone、REL-01/02 | `v0.2.0`、双版本 CI 和 required gate 通过 |
 | M2.1 Benchmark 注册与配置契约 | ✅ 已完成 | U4、U6 | BENCH-01 | 静态 registry、config v2、双版本 45 项测试和 required gate 通过 |
-| M2.2 首个多路径缩减基准 | 🔄 进行中 | U4 | BENCH-02 | FourBranch reduced 的输入身份、trace 与重复性证据完整 |
+| M2.2 首个多路径缩减基准 | ✅ 已完成 | U4 | BENCH-02 | FourBranch reduced 的输入身份、DoI、trace、重复性和 PR #6 required gate 通过 |
 | M2.3 多问题 Benchmark 验收 | ⏳ 待开始 | U4 | BENCH-03--06 | 至少三个不同性质 benchmark 通过统一验收 |
 | M3 包装与跨环境质量 | ⏳ 待开始 | U6 | PKG-01--04、CI-01、SCHEMA-01 | 包装、版本源、schema 验证和跨平台 CI 达到发布门 |
 
@@ -63,7 +63,7 @@
 | U1 Legacy 基准恢复 | ⛔ 阻塞 | 可恢复证据有限；历史候选池、测试集和 RNG/CV 状态缺失 | 执行 Legacy 环境审计并形成正式阻塞结论 |
 | U2 Modern 核心实现 | ✅ 已完成 | 核心算法完成，当前发布基线为 `v0.2.0` | 核心变更继续遵守裁决和回归门 |
 | U3 内核与逐轮行为回归 | ✅ 已完成（可获得证据范围） | Phase 5--8 证据完整；历史 FourBranch trace 不可用 | 建立统一结案矩阵，与 U1 阻塞结论互链 |
-| U4 通用软件 benchmark | 🔄 进行中 | M2.1 registry/config v2 完成；多问题扩展是当前主线 | 实现 M2.2 FourBranch reduced benchmark |
+| U4 通用软件 benchmark | 🔄 进行中 | M2.1 registry/config v2 与 M2.2 FourBranch reduced 完成 | 决定并启动 M2.3 的下一个 reduced benchmark |
 | U5 Runner 发布门 | ✅ 已完成 | M1 schema、CLI、示例、evidence、PR #4 和 `v0.2.0` 发布均完成 | 按版本化流程维护后续交付 |
 | U6 版本化维护 | 🔄 进行中 | required CI 和版本化变更流程已建立 | 持续处理 benchmark、包装和依赖质量任务 |
 
@@ -76,12 +76,12 @@
 | REL-01 | M0/M1 / P0 | 合并 M0/M1 交付 | PR #4；Python 3.11/3.12 和聚合 gate 全部通过 | ✅ 已合并到 `master` |
 | REL-02 | M1 / P0 | 发布 `v0.2.0` | tag、GitHub Release、required gate | ✅ 已发布 |
 | BENCH-01 | M2.1 / P1 | 受控 benchmark registry/config v2 | PR #6；Python 3.11/3.12 均 `45 passed`；required gate 通过 | ✅ 完成，作为 M2.2 注册入口 |
+| BENCH-02 | M2.2 / P1 | FourBranch reduced benchmark | 三套独立冻结输入、显式失效定义、DoI/manifest/trace 重复性；PR #6 双版本 `47 passed` | ✅ 完成；不声明为历史 replay 或论文生产结果 |
 
 ### 🔄 进行中
 
-| ID | 归属 / 优先级 | 任务 | 当前证据 | 完成门 |
-| --- | --- | --- | --- | --- |
-| BENCH-02 | M2.2 / P1 | FourBranch reduced benchmark | `four_branch_reduced_v1` 已注册；三套独立 seed/shape/hash 已冻结；DoI 路径和 manifest 重复性通过；Python 3.11/3.12 均 `46 passed` | 远端双版本 CI 和审查通过后完成 |
+当前无已启动的离散任务；U6 持续维护不在此处重复列项。M2.3 的具体 benchmark
+仍为 ⏳，需单独启动后再移入本节。
 
 ### ⏳ 待开始
 

--- a/specs/UQRA_PROJECT_PROGRESS_BOARD.md
+++ b/specs/UQRA_PROJECT_PROGRESS_BOARD.md
@@ -29,9 +29,9 @@
 | --- | --- | --- |
 | 默认分支 | `master` | ✅ `v0.2.0` 已发布 |
 | 当前工作分支 | `codex/normalize-roadmap-numbering` | 🔄 统一里程碑与任务编号 |
-| 最近 PR | [#5 Update project progress board for v0.2.0](https://github.com/Jinsongl/UQRA/pull/5) | ✅ 已合并 |
-| Python 3.11 | `42 passed` | ✅ [CI run 30972668606](https://github.com/Jinsongl/UQRA/actions/runs/30972668606) |
-| Python 3.12 | `42 passed` | ✅ [CI run 30972668606](https://github.com/Jinsongl/UQRA/actions/runs/30972668606) |
+| 最近 PR | [#6 Add M2.1 benchmark registry contract](https://github.com/Jinsongl/UQRA/pull/6) | 🔄 Draft；CI 已通过 |
+| Python 3.11 | `45 passed` | ✅ [CI run 30978105375](https://github.com/Jinsongl/UQRA/actions/runs/30978105375) |
+| Python 3.12 | `45 passed` | ✅ [CI run 30978105375](https://github.com/Jinsongl/UQRA/actions/runs/30978105375) |
 | Required check | `Adaptive compatibility gate` | ✅ 通过 |
 | 全新克隆验收 | Python 3.11.15，`42 passed`，smoke/full manifest 有效 | ✅ [`UQRA_V0.1.0_EVIDENCE.md`](releases/UQRA_V0.1.0_EVIDENCE.md) |
 | 当前 Release | [`v0.2.0`](https://github.com/Jinsongl/UQRA/releases/tag/v0.2.0) | ✅ 指向合并提交 `3445464d` |
@@ -47,8 +47,8 @@
 | --- | --- | --- | --- | --- |
 | M0 治理与边界 | ✅ 已完成 | U0 | 计划与边界文档 | 进入版本控制并明确项目/论文边界 |
 | M1 Runner 契约与可审计发布（原 UQRA-MV1） | ✅ 已完成 | U5、U6 | schema、CLI、示例、evidence、clean-clone、REL-01/02 | `v0.2.0`、双版本 CI 和 required gate 通过 |
-| M2.1 Benchmark 注册与配置契约 | 🔄 进行中 | U4、U6 | BENCH-01 | 本地实现与双版本 45 项测试通过；待远端 CI/审查 |
-| M2.2 首个多路径缩减基准 | ⏳ 待开始 | U4 | BENCH-02 | FourBranch reduced 的输入身份、trace 与重复性证据完整 |
+| M2.1 Benchmark 注册与配置契约 | ✅ 已完成 | U4、U6 | BENCH-01 | 静态 registry、config v2、双版本 45 项测试和 required gate 通过 |
+| M2.2 首个多路径缩减基准 | 🔄 进行中 | U4 | BENCH-02 | FourBranch reduced 的输入身份、trace 与重复性证据完整 |
 | M2.3 多问题 Benchmark 验收 | ⏳ 待开始 | U4 | BENCH-03--06 | 至少三个不同性质 benchmark 通过统一验收 |
 | M3 包装与跨环境质量 | ⏳ 待开始 | U6 | PKG-01--04、CI-01、SCHEMA-01 | 包装、版本源、schema 验证和跨平台 CI 达到发布门 |
 
@@ -63,7 +63,7 @@
 | U1 Legacy 基准恢复 | ⛔ 阻塞 | 可恢复证据有限；历史候选池、测试集和 RNG/CV 状态缺失 | 执行 Legacy 环境审计并形成正式阻塞结论 |
 | U2 Modern 核心实现 | ✅ 已完成 | 核心算法完成，当前发布基线为 `v0.2.0` | 核心变更继续遵守裁决和回归门 |
 | U3 内核与逐轮行为回归 | ✅ 已完成（可获得证据范围） | Phase 5--8 证据完整；历史 FourBranch trace 不可用 | 建立统一结案矩阵，与 U1 阻塞结论互链 |
-| U4 通用软件 benchmark | 🔄 进行中 | 二维 Hermite 缩减 benchmark 完成；多问题扩展是当前主线 | 启动受控 benchmark registry/config v2 |
+| U4 通用软件 benchmark | 🔄 进行中 | M2.1 registry/config v2 完成；多问题扩展是当前主线 | 实现 M2.2 FourBranch reduced benchmark |
 | U5 Runner 发布门 | ✅ 已完成 | M1 schema、CLI、示例、evidence、PR #4 和 `v0.2.0` 发布均完成 | 按版本化流程维护后续交付 |
 | U6 版本化维护 | 🔄 进行中 | required CI 和版本化变更流程已建立 | 持续处理 benchmark、包装和依赖质量任务 |
 
@@ -75,18 +75,18 @@
 | --- | --- | --- | --- | --- |
 | REL-01 | M0/M1 / P0 | 合并 M0/M1 交付 | PR #4；Python 3.11/3.12 和聚合 gate 全部通过 | ✅ 已合并到 `master` |
 | REL-02 | M1 / P0 | 发布 `v0.2.0` | tag、GitHub Release、required gate | ✅ 已发布 |
+| BENCH-01 | M2.1 / P1 | 受控 benchmark registry/config v2 | PR #6；Python 3.11/3.12 均 `45 passed`；required gate 通过 | ✅ 完成，作为 M2.2 注册入口 |
 
 ### 🔄 进行中
 
 | ID | 归属 / 优先级 | 任务 | 当前证据 | 完成门 |
 | --- | --- | --- | --- | --- |
-| BENCH-01 | M2.1 / P1 | 设计受控 benchmark registry/config v2 | 静态 registry、v2 schema、两个示例；Python 3.11/3.12 均 `45 passed` | 禁止任意 Python 导入；配置能选择已注册 benchmark；远端 CI 和审查通过 |
+| BENCH-02 | M2.2 / P1 | FourBranch reduced benchmark | BENCH-01 已完成；开始定义冻结输入与配置 | 固定输入/seed/hash、DoI 路径、manifest、trace 和重复性测试通过 |
 
 ### ⏳ 待开始
 
 | ID | 归属 / 优先级 | 任务 | 前置条件 | 完成门 |
 | --- | --- | --- | --- | --- |
-| BENCH-02 | M2.2 / P1 | FourBranch reduced benchmark | BENCH-01 | 固定输入/seed/hash、DoI 路径、manifest、trace 和重复性测试通过 |
 | LEG-01 | U1 / P1 | Legacy Python 3.8/3.9 环境审计 | 无 | 依赖、可运行入口和失败类型形成可审计报告 |
 | REG-01 | U3 / P1 | U3 行为回归结案矩阵 | LEG-01 可并行 | 已验证项与 `unavailable` 项逐项对应证据，无状态歧义 |
 

--- a/specs/UQRA_PROJECT_PROGRESS_BOARD.md
+++ b/specs/UQRA_PROJECT_PROGRESS_BOARD.md
@@ -81,7 +81,7 @@
 
 | ID | 归属 / 优先级 | 任务 | 当前证据 | 完成门 |
 | --- | --- | --- | --- | --- |
-| BENCH-02 | M2.2 / P1 | FourBranch reduced benchmark | BENCH-01 已完成；开始定义冻结输入与配置 | 固定输入/seed/hash、DoI 路径、manifest、trace 和重复性测试通过 |
+| BENCH-02 | M2.2 / P1 | FourBranch reduced benchmark | `four_branch_reduced_v1` 已注册；三套独立 seed/shape/hash 已冻结；DoI 路径和 manifest 重复性通过；Python 3.11/3.12 均 `46 passed` | 远端双版本 CI 和审查通过后完成 |
 
 ### ⏳ 待开始
 

--- a/tests/compatibility/test_adaptive_runner.py
+++ b/tests/compatibility/test_adaptive_runner.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from uqra.adaptive.benchmark_registry import benchmark_names, get_benchmark
+from uqra.adaptive.four_branch_reduced import INPUT_HASHES
 from uqra.adaptive.run import (CONFIG_SCHEMA, CONFIG_SCHEMA_V2, MANIFEST_SCHEMA, TRACE_SCHEMA,
                                load_config, main, run_config, validate_config,
                                validate_manifest)
@@ -12,6 +13,7 @@ from uqra.adaptive.run import (CONFIG_SCHEMA, CONFIG_SCHEMA_V2, MANIFEST_SCHEMA,
 ROOT = Path(__file__).resolve().parents[2]
 SMOKE_CONFIG = ROOT / "examples" / "configs" / "adaptive_reduced_smoke.json"
 V2_SMOKE_CONFIG = ROOT / "examples" / "configs" / "adaptive_registry_v2_smoke.json"
+FOUR_BRANCH_CONFIG = ROOT / "examples" / "configs" / "four_branch_reduced_v1.json"
 
 
 def test_published_json_schemas_and_examples_are_well_formed():
@@ -30,6 +32,7 @@ def test_published_json_schemas_and_examples_are_well_formed():
         ROOT / "examples" / "configs" / "adaptive_reduced_full.json": CONFIG_SCHEMA,
         V2_SMOKE_CONFIG: CONFIG_SCHEMA_V2,
         ROOT / "examples" / "configs" / "adaptive_registry_v2_full.json": CONFIG_SCHEMA_V2,
+        FOUR_BRANCH_CONFIG: CONFIG_SCHEMA_V2,
     }
     for path, expected_schema in examples.items():
         assert load_config(path)["schema"] == expected_schema
@@ -80,6 +83,25 @@ def test_v2_registry_config_is_valid_and_repeatable():
     assert validate_manifest(first)
     assert first["stable_manifest_hash"] == second["stable_manifest_hash"]
     assert first["config"]["schema"] == CONFIG_SCHEMA_V2
+
+
+def test_four_branch_reduced_config_is_registered_and_repeatable():
+    config = load_config(FOUR_BRANCH_CONFIG)
+    first = run_config(config)
+    second = run_config(config)
+    assert validate_manifest(first)
+    assert first["stable_manifest_hash"] == second["stable_manifest_hash"]
+    run = first["run"]
+    assert run["input"]["historical_replay"] is False
+    datasets = run["input"]["datasets"]
+    assert len({item["seed"] for item in datasets.values()}) == 3
+    assert len({item["sha256"] for item in datasets.values()}) == 3
+    assert {name: item["sha256"] for name, item in datasets.items()} == INPUT_HASHES
+    result = run["scenarios"]["reduced"]
+    assert result["candidate_hash"] == datasets["candidate"]["sha256"]
+    assert result["test_hash"] == datasets["test"]["sha256"]
+    assert result["reference_hash"] == datasets["reference"]["sha256"]
+    assert result["stage_counts"]["doi_constructed"] >= 1
 
 
 def test_config_driven_cli_writes_manifest(tmp_path):

--- a/tests/compatibility/test_adaptive_runner.py
+++ b/tests/compatibility/test_adaptive_runner.py
@@ -3,18 +3,21 @@ from pathlib import Path
 
 import pytest
 
-from uqra.adaptive.run import (CONFIG_SCHEMA, MANIFEST_SCHEMA, TRACE_SCHEMA,
+from uqra.adaptive.benchmark_registry import benchmark_names, get_benchmark
+from uqra.adaptive.run import (CONFIG_SCHEMA, CONFIG_SCHEMA_V2, MANIFEST_SCHEMA, TRACE_SCHEMA,
                                load_config, main, run_config, validate_config,
                                validate_manifest)
 
 
 ROOT = Path(__file__).resolve().parents[2]
 SMOKE_CONFIG = ROOT / "examples" / "configs" / "adaptive_reduced_smoke.json"
+V2_SMOKE_CONFIG = ROOT / "examples" / "configs" / "adaptive_registry_v2_smoke.json"
 
 
 def test_published_json_schemas_and_examples_are_well_formed():
     schemas = {
         "adaptive-runner-config.schema.json": CONFIG_SCHEMA,
+        "adaptive-runner-config-v2.schema.json": CONFIG_SCHEMA_V2,
         "adaptive-runner-manifest.schema.json": MANIFEST_SCHEMA,
         "adaptive-trace.schema.json": TRACE_SCHEMA,
     }
@@ -22,8 +25,30 @@ def test_published_json_schemas_and_examples_are_well_formed():
         payload = json.loads((ROOT / "schemas" / name).read_text(encoding="utf-8"))
         assert payload["$schema"] == "https://json-schema.org/draft/2020-12/schema"
         assert payload["$id"].endswith(name)
-    for path in (SMOKE_CONFIG, ROOT / "examples" / "configs" / "adaptive_reduced_full.json"):
-        assert load_config(path)["schema"] == CONFIG_SCHEMA
+    examples = {
+        SMOKE_CONFIG: CONFIG_SCHEMA,
+        ROOT / "examples" / "configs" / "adaptive_reduced_full.json": CONFIG_SCHEMA,
+        V2_SMOKE_CONFIG: CONFIG_SCHEMA_V2,
+        ROOT / "examples" / "configs" / "adaptive_registry_v2_full.json": CONFIG_SCHEMA_V2,
+    }
+    for path, expected_schema in examples.items():
+        assert load_config(path)["schema"] == expected_schema
+
+
+def test_v2_schema_benchmark_enum_matches_static_registry():
+    schema = json.loads(
+        (ROOT / "schemas" / "adaptive-runner-config-v2.schema.json").read_text(encoding="utf-8")
+    )
+    configured_names = schema["properties"]["runner"]["properties"]["benchmark"]["enum"]
+    assert configured_names == list(benchmark_names())
+    assert get_benchmark(configured_names[0]).name == configured_names[0]
+
+
+def test_registry_rejects_module_paths_and_unknown_benchmarks():
+    config = load_config(V2_SMOKE_CONFIG)
+    config["runner"]["benchmark"] = "package.module:benchmark"
+    with pytest.raises(ValueError, match="unsupported benchmark"):
+        validate_config(config)
 
 
 def test_runner_rejects_paper_production_and_unknown_fields():
@@ -46,6 +71,15 @@ def test_config_driven_smoke_manifest_is_valid_and_repeatable():
     assert first["purpose"] == "software_benchmark"
     assert first["scale"] == "reduced"
     assert set(first["run"]["scenarios"]) == {"converged"}
+
+
+def test_v2_registry_config_is_valid_and_repeatable():
+    config = load_config(V2_SMOKE_CONFIG)
+    first = run_config(config)
+    second = run_config(config)
+    assert validate_manifest(first)
+    assert first["stable_manifest_hash"] == second["stable_manifest_hash"]
+    assert first["config"]["schema"] == CONFIG_SCHEMA_V2
 
 
 def test_config_driven_cli_writes_manifest(tmp_path):

--- a/tests/compatibility/test_adaptive_runner.py
+++ b/tests/compatibility/test_adaptive_runner.py
@@ -54,6 +54,14 @@ def test_registry_rejects_module_paths_and_unknown_benchmarks():
         validate_config(config)
 
 
+def test_v1_contract_cannot_select_v2_registry_benchmarks():
+    config = load_config(SMOKE_CONFIG)
+    config["runner"]["benchmark"] = "four_branch_reduced_v1"
+    config["runner"]["scenarios"] = ["reduced"]
+    with pytest.raises(ValueError, match="v1 only supports"):
+        validate_config(config)
+
+
 def test_runner_rejects_paper_production_and_unknown_fields():
     config = load_config(SMOKE_CONFIG)
     config["purpose"] = "paper_production"

--- a/uqra/adaptive/benchmark_registry.py
+++ b/uqra/adaptive/benchmark_registry.py
@@ -10,6 +10,9 @@ from types import MappingProxyType
 from typing import Callable, Mapping, Sequence
 
 from .benchmark import BENCHMARK_NAME, run_suite
+from .four_branch_reduced import (BENCHMARK_NAME as FOUR_BRANCH_NAME,
+                                  SCENARIO as FOUR_BRANCH_SCENARIO,
+                                  run_suite as run_four_branch_suite)
 
 
 @dataclass(frozen=True)
@@ -26,6 +29,11 @@ _REGISTRY = {
         name=BENCHMARK_NAME,
         scenarios=("converged", "max_order", "overfit_fallback", "runtime_failure"),
         run=run_suite,
+    ),
+    FOUR_BRANCH_NAME: BenchmarkDefinition(
+        name=FOUR_BRANCH_NAME,
+        scenarios=(FOUR_BRANCH_SCENARIO,),
+        run=run_four_branch_suite,
     ),
 }
 

--- a/uqra/adaptive/benchmark_registry.py
+++ b/uqra/adaptive/benchmark_registry.py
@@ -1,0 +1,46 @@
+"""Static registry for supported reduced software benchmarks.
+
+The registry deliberately contains callables owned by UQRA. Configuration files
+select a public name and can never provide a Python module or import path.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Callable, Mapping, Sequence
+
+from .benchmark import BENCHMARK_NAME, run_suite
+
+
+@dataclass(frozen=True)
+class BenchmarkDefinition:
+    """A configuration-visible benchmark and its supported scenarios."""
+
+    name: str
+    scenarios: tuple[str, ...]
+    run: Callable[[Sequence[str] | None], dict]
+
+
+_REGISTRY = {
+    BENCHMARK_NAME: BenchmarkDefinition(
+        name=BENCHMARK_NAME,
+        scenarios=("converged", "max_order", "overfit_fallback", "runtime_failure"),
+        run=run_suite,
+    ),
+}
+
+BENCHMARK_REGISTRY: Mapping[str, BenchmarkDefinition] = MappingProxyType(_REGISTRY)
+
+
+def benchmark_names() -> tuple[str, ...]:
+    """Return registered public names in deterministic order."""
+    return tuple(sorted(BENCHMARK_REGISTRY))
+
+
+def get_benchmark(name: str) -> BenchmarkDefinition:
+    """Resolve a public benchmark name without importing user-provided code."""
+    try:
+        return BENCHMARK_REGISTRY[name]
+    except (KeyError, TypeError) as error:
+        supported = ", ".join(benchmark_names())
+        raise ValueError(f"unsupported benchmark: {name!r}; registered: {supported}") from error

--- a/uqra/adaptive/four_branch_reduced.py
+++ b/uqra/adaptive/four_branch_reduced.py
@@ -1,0 +1,142 @@
+"""Deterministic reduced FourBranch software benchmark.
+
+This is a newly generated software fixture, not a reconstruction of the
+unavailable historical FourBranch candidate or test data.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import asdict
+import hashlib
+import json
+
+import numpy as np
+
+from .controller import AdaptiveSparsePCE
+from .profiles import publication_profile
+from .state import array_hash
+
+
+BENCHMARK_NAME = "four_branch_reduced_v1"
+SCENARIO = "reduced"
+CANDIDATE_SEED = 26080501
+TEST_SEED = 26080502
+REFERENCE_SEED = 26080503
+CV_SEED = 26080504
+SIZES = {"candidate": 192, "test": 256, "reference": 4096}
+INPUT_HASHES = {
+    "candidate": "01ca05dc7f0312570cd13e6514b869683e1f7247b42c4dae72b5a1c05281538a",
+    "test": "2ea6903f46a4e79f8d3844221a6dae21c16a28328b42150046eec3eed8058b42",
+    "reference": "96d87567367d58e82dff38f84e05a01a608a1a6b7ba5a3491b012e67d2f5f5db",
+}
+
+
+def four_branch_limit_state(xi):
+    """Return g=min(g1,...,g4); failure is explicitly g <= 0."""
+    xi = np.asarray(xi, dtype=float).reshape(2, -1)
+    x1, x2 = xi
+    root2 = np.sqrt(2.0)
+    branches = np.vstack((
+        3.0 + 0.1 * (x1 - x2) ** 2 - (x1 + x2) / root2,
+        3.0 + 0.1 * (x1 - x2) ** 2 + (x1 + x2) / root2,
+        x1 - x2 + 7.0 / root2,
+        x2 - x1 + 7.0 / root2,
+    ))
+    return np.min(branches, axis=0)
+
+
+def frozen_inputs():
+    """Return independent, read-only candidate, test, and reference arrays."""
+    arrays = {
+        "candidate": np.random.default_rng(CANDIDATE_SEED).normal(size=(2, SIZES["candidate"])),
+        "test": np.random.default_rng(TEST_SEED).normal(size=(2, SIZES["test"])),
+        "reference": np.random.default_rng(REFERENCE_SEED).normal(size=(2, SIZES["reference"])),
+    }
+    for array in arrays.values():
+        array.setflags(write=False)
+    actual = {name: array_hash(array) for name, array in arrays.items()}
+    if actual != INPUT_HASHES:
+        raise RuntimeError(f"FourBranch reduced frozen input hash mismatch: {actual}")
+    return arrays
+
+
+def _vandermonde(order, xi):
+    from uqra.polynomial.hermite import Hermite
+    return Hermite(d=2, deg=order, hem_type="probabilists").vandermonde(xi)
+
+
+def _identity_payload(arrays):
+    seeds = {"candidate": CANDIDATE_SEED, "test": TEST_SEED, "reference": REFERENCE_SEED}
+    return {
+        name: {
+            "role": name,
+            "rng": "numpy.random.Generator(PCG64)",
+            "seed": seeds[name],
+            "shape": list(array.shape),
+            "sha256": array_hash(array),
+        }
+        for name, array in arrays.items()
+    }
+
+
+def run_scenario():
+    arrays = frozen_inputs()
+    candidate, test, reference = (arrays[name] for name in ("candidate", "test", "reference"))
+    test_g = four_branch_limit_state(test)
+    boundary_ids = np.argsort(np.abs(test_g), kind="stable")[:8]
+    profile = publication_profile(
+        cv_folds=4, cv_seed=CV_SEED, qoi_tolerance=1e-3,
+        outer_stable_checks=1, inner_qoi_tolerance=None,
+        max_inner_iterations=3, minimum_doi_size=8, overfit_rebuild=False,
+    )
+    runner = AdaptiveSparsePCE(
+        candidate, _vandermonde, four_branch_limit_state, profile,
+        order_min=2, order_max=4, test_xi=test,
+        qoi=lambda values: np.mean(np.asarray(values) <= 0.0),
+        doi_centers=test[:, boundary_ids], doi_radius=0.75, criterion="S",
+        random_state=CANDIDATE_SEED,
+    )
+    result = runner.run()
+    result.state.assert_invariants()
+    stages = Counter(row.stage for row in result.trace)
+    return {
+        "scenario": SCENARIO,
+        "status": result.status,
+        "stop_reason": result.stop_reason,
+        "candidate_hash": array_hash(candidate),
+        "test_hash": array_hash(test),
+        "reference_hash": array_hash(reference),
+        "reference_failure_probability": float(np.mean(four_branch_limit_state(reference) <= 0.0)),
+        "doi_center_test_ids": boundary_ids.tolist(),
+        "trace_hash": result.trace_hash(),
+        "trace_rows": len(result.trace),
+        "stage_counts": dict(sorted(stages.items())),
+        "model_call_count": result.state.model_call_count,
+        "evaluated_global_ids": list(result.state.evaluated_global_ids),
+        "evaluated_coordinate_hashes": sorted(result.state.evaluated_coordinate_hashes),
+        "trace": [asdict(row) for row in result.trace],
+    }
+
+
+def run_suite(scenarios=None):
+    scenarios = list(scenarios or (SCENARIO,))
+    if scenarios != [SCENARIO]:
+        raise ValueError(f"{BENCHMARK_NAME} supports only the {SCENARIO!r} scenario")
+    arrays = frozen_inputs()
+    manifest = {
+        "schema_version": 1,
+        "benchmark": BENCHMARK_NAME,
+        "input": {
+            "purpose": "software_benchmark",
+            "scale": "reduced",
+            "historical_replay": False,
+            "failure_definition": "min(g1,g2,g3,g4) <= 0",
+            "cv_seed": CV_SEED,
+            "datasets": _identity_payload(arrays),
+        },
+        "scenarios": {SCENARIO: run_scenario()},
+    }
+    manifest["stable_manifest_hash"] = hashlib.sha256(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    ).hexdigest()
+    return manifest

--- a/uqra/adaptive/run.py
+++ b/uqra/adaptive/run.py
@@ -17,6 +17,7 @@ SUPPORTED_CONFIG_SCHEMAS = {CONFIG_SCHEMA, CONFIG_SCHEMA_V2}
 MANIFEST_SCHEMA = "uqra.adaptive.runner-manifest/v1"
 TRACE_SCHEMA = "uqra.adaptive.trace/v1"
 RUNNER_KIND = "deterministic_benchmark"
+V1_BENCHMARK = "phase8_two_dimensional_hermite"
 
 
 def _canonical_hash(payload) -> str:
@@ -49,6 +50,8 @@ def validate_config(config):
         raise ValueError("runner fields must be exactly: kind, benchmark, scenarios")
     if runner["kind"] != RUNNER_KIND:
         raise ValueError(f"unsupported runner kind: {runner['kind']!r}")
+    if config["schema"] == CONFIG_SCHEMA and runner["benchmark"] != V1_BENCHMARK:
+        raise ValueError(f"runner config v1 only supports benchmark: {V1_BENCHMARK}")
     benchmark = get_benchmark(runner["benchmark"])
     scenarios = runner["scenarios"]
     if (not isinstance(scenarios, list) or not scenarios

--- a/uqra/adaptive/run.py
+++ b/uqra/adaptive/run.py
@@ -8,14 +8,15 @@ import json
 from pathlib import Path
 import sys
 
-from .benchmark import BENCHMARK_NAME, run_suite
+from .benchmark_registry import get_benchmark
 
 
 CONFIG_SCHEMA = "uqra.adaptive.runner-config/v1"
+CONFIG_SCHEMA_V2 = "uqra.adaptive.runner-config/v2"
+SUPPORTED_CONFIG_SCHEMAS = {CONFIG_SCHEMA, CONFIG_SCHEMA_V2}
 MANIFEST_SCHEMA = "uqra.adaptive.runner-manifest/v1"
 TRACE_SCHEMA = "uqra.adaptive.trace/v1"
 RUNNER_KIND = "deterministic_benchmark"
-SCENARIOS = {"converged", "max_order", "overfit_fallback", "runtime_failure"}
 
 
 def _canonical_hash(payload) -> str:
@@ -35,7 +36,7 @@ def validate_config(config):
         raise ValueError(f"runner config missing fields: {', '.join(missing)}")
     if unknown:
         raise ValueError(f"runner config has unknown fields: {', '.join(unknown)}")
-    if config["schema"] != CONFIG_SCHEMA:
+    if config["schema"] not in SUPPORTED_CONFIG_SCHEMAS:
         raise ValueError(f"unsupported runner config schema: {config['schema']!r}")
     if config["purpose"] != "software_benchmark" or config["scale"] != "reduced":
         raise ValueError("this entry point only accepts reduced software_benchmark configs")
@@ -48,15 +49,14 @@ def validate_config(config):
         raise ValueError("runner fields must be exactly: kind, benchmark, scenarios")
     if runner["kind"] != RUNNER_KIND:
         raise ValueError(f"unsupported runner kind: {runner['kind']!r}")
-    if runner["benchmark"] != BENCHMARK_NAME:
-        raise ValueError(f"unsupported benchmark: {runner['benchmark']!r}")
+    benchmark = get_benchmark(runner["benchmark"])
     scenarios = runner["scenarios"]
     if (not isinstance(scenarios, list) or not scenarios
             or any(not isinstance(item, str) for item in scenarios)):
         raise ValueError("runner.scenarios must be a non-empty string array")
     if len(scenarios) != len(set(scenarios)):
         raise ValueError("runner.scenarios must not contain duplicates")
-    unsupported = sorted(set(scenarios).difference(SCENARIOS))
+    unsupported = sorted(set(scenarios).difference(benchmark.scenarios))
     if unsupported:
         raise ValueError(f"unsupported scenarios: {', '.join(unsupported)}")
 
@@ -90,13 +90,14 @@ def validate_manifest(manifest):
     if manifest["config_hash"] != _canonical_hash(manifest["config"]):
         raise ValueError("runner manifest config hash is invalid")
     run = manifest["run"]
-    if not isinstance(run, dict) or run.get("benchmark") != BENCHMARK_NAME:
+    if not isinstance(run, dict):
         raise ValueError("runner manifest benchmark is invalid")
+    benchmark = get_benchmark(run.get("benchmark"))
     scenarios = run.get("scenarios")
     if not isinstance(scenarios, dict) or not scenarios:
         raise ValueError("runner manifest has no scenario results")
     for name, result in scenarios.items():
-        if name not in SCENARIOS or not isinstance(result, dict):
+        if name not in benchmark.scenarios or not isinstance(result, dict):
             raise ValueError(f"runner manifest scenario is invalid: {name!r}")
         if result.get("scenario") != name or not isinstance(result.get("trace"), list):
             raise ValueError(f"runner manifest trace is invalid: {name!r}")
@@ -115,7 +116,8 @@ def validate_manifest(manifest):
 
 def run_config(config):
     config = validate_config(config)
-    benchmark_manifest = run_suite(config["runner"]["scenarios"])
+    benchmark = get_benchmark(config["runner"]["benchmark"])
+    benchmark_manifest = benchmark.run(config["runner"]["scenarios"])
     manifest = {
         "schema": MANIFEST_SCHEMA,
         "trace_schema": TRACE_SCHEMA,


### PR DESCRIPTION
## Summary

- normalize the roadmap into U workstreams, M delivery milestones, and stable task IDs
- add the M2.1 static benchmark registry and runner config v2 contract
- add two v2 examples while preserving the published v1 configuration contract
- update the progress board and README with the active M2.1 delivery path

## Why

The existing runner and schema hard-coded one benchmark name, while the roadmap referred to M2.1 only indirectly through `BENCH-01`. This change makes the milestone mapping explicit and provides a controlled extension point for reduced software benchmarks.

## Safety and compatibility

- configuration can select only names in the UQRA-owned static registry
- Python module paths and configuration-driven imports are rejected
- runner config v1 remains supported and the v0.2.0 evidence examples are unchanged
- M2.1 remains in progress until remote review and the required compatibility gate pass

## Validation

- Python 3.11 compatibility suite: `45 passed`
- Python 3.12 compatibility suite: `45 passed`
- config v2 smoke runner generated and validated a manifest
- `git diff --check`
