### PR TITLE
Validate published runner schemas

### DIFF
--- a/requirements/compatibility-py311.txt
+++ b/requirements/compatibility-py311.txt
@@ -19,3 +19,9 @@ six==1.17.0
 colorama==0.4.6
 setuptools==75.8.2
 wheel==0.45.1
+jsonschema==4.23.0
+jsonschema-specifications==2025.4.1
+referencing==0.36.2
+rpds-py==0.26.0
+attrs==25.3.0
+typing-extensions==4.16.0

--- a/requirements/compatibility-py312.txt
+++ b/requirements/compatibility-py312.txt
@@ -19,3 +19,9 @@ six==1.17.0
 colorama==0.4.6
 setuptools==75.8.2
 wheel==0.45.1
+jsonschema==4.23.0
+jsonschema-specifications==2025.4.1
+referencing==0.36.2
+rpds-py==0.26.0
+attrs==25.3.0
+typing-extensions==4.16.0

--- a/schemas/adaptive-runner-config-v2.schema.json
+++ b/schemas/adaptive-runner-config-v2.schema.json
@@ -32,5 +32,30 @@
       "required": ["manifest"],
       "properties": {"manifest": {"type": "string", "minLength": 1}}
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "runner": {"properties": {"benchmark": {"const": "phase8_two_dimensional_hermite"}}}
+        }
+      },
+      "then": {
+        "properties": {
+          "runner": {
+            "properties": {
+              "scenarios": {
+                "items": {"enum": ["converged", "max_order", "overfit_fallback", "runtime_failure"]}
+              }
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "runner": {"properties": {"scenarios": {"const": ["reduced"]}}}
+        }
+      }
+    }
+  ]
 }

--- a/schemas/adaptive-runner-manifest.schema.json
+++ b/schemas/adaptive-runner-manifest.schema.json
@@ -11,38 +11,76 @@
     "purpose": {"const": "software_benchmark"},
     "scale": {"const": "reduced"},
     "config_hash": {"$ref": "#/$defs/hash"},
-    "config": {"$ref": "adaptive-runner-config.schema.json"},
+    "config": {
+      "oneOf": [
+        {"$ref": "adaptive-runner-config.schema.json"},
+        {"$ref": "adaptive-runner-config-v2.schema.json"}
+      ]
+    },
     "stable_manifest_hash": {"$ref": "#/$defs/hash"},
+    "run": {"$ref": "#/$defs/run"}
+  },
+  "$defs": {
+    "hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "scenario": {
+      "type": "object",
+      "required": ["scenario", "status", "stop_reason", "trace_hash", "trace"],
+      "properties": {
+        "scenario": {"type": "string", "minLength": 1},
+        "status": {"type": "string", "minLength": 1},
+        "stop_reason": {"type": "string", "minLength": 1},
+        "trace_hash": {"$ref": "#/$defs/hash"},
+        "contract_trace_hash": {"$ref": "#/$defs/hash"},
+        "trace": {"type": "array", "items": {"$ref": "adaptive-trace.schema.json"}}
+      }
+    },
     "run": {
       "type": "object",
-      "required": ["schema_version", "benchmark", "input", "git", "dependencies", "reproduce_command", "scenarios", "stable_manifest_hash"],
+      "additionalProperties": false,
+      "required": ["schema_version", "benchmark", "input", "scenarios", "stable_manifest_hash"],
       "properties": {
         "schema_version": {"const": 1},
-        "benchmark": {"const": "phase8_two_dimensional_hermite"},
+        "benchmark": {"enum": ["four_branch_reduced_v1", "gayton_reduced_v1", "ishigami_reduced_v1", "phase8_two_dimensional_hermite"]},
         "input": {"type": "object"},
         "git": {"type": "object"},
         "dependencies": {"type": "object"},
-        "reproduce_command": {"type": "string"},
+        "reproduce_command": {"type": "string", "minLength": 1},
+        "contract_manifest_hash": {"$ref": "#/$defs/hash"},
         "stable_manifest_hash": {"$ref": "#/$defs/hash"},
         "scenarios": {
           "type": "object",
           "minProperties": 1,
-          "additionalProperties": {
-            "type": "object",
-            "required": ["scenario", "status", "stop_reason", "trace_hash", "trace"],
+          "additionalProperties": {"$ref": "#/$defs/scenario"}
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"benchmark": {"const": "phase8_two_dimensional_hermite"}}},
+          "then": {"required": ["git", "dependencies", "reproduce_command"]},
+          "else": {
+            "required": ["contract_manifest_hash"],
             "properties": {
-              "scenario": {"type": "string"},
-              "status": {"type": "string"},
-              "stop_reason": {"type": "string"},
-              "trace_hash": {"$ref": "#/$defs/hash"},
-              "trace": {"type": "array", "items": {"$ref": "adaptive-trace.schema.json"}}
+              "input": {
+                "required": ["purpose", "scale", "historical_replay", "paper_production", "datasets"],
+                "properties": {
+                  "purpose": {"const": "software_benchmark"},
+                  "scale": {"const": "reduced"},
+                  "historical_replay": {"const": false},
+                  "paper_production": {"const": false},
+                  "datasets": {
+                    "type": "object",
+                    "required": ["candidate", "test", "reference"]
+                  }
+                }
+              },
+              "scenarios": {
+                "required": ["reduced"],
+                "properties": {"reduced": {"required": ["contract_trace_hash"]}}
+              }
             }
           }
         }
-      }
+      ]
     }
-  },
-  "$defs": {
-    "hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
   }
 }

--- a/specs/UQRA_PROJECT_DEVELOPMENT_PLAN.md
+++ b/specs/UQRA_PROJECT_DEVELOPMENT_PLAN.md
@@ -173,7 +173,7 @@ Python 3.12.13 完整兼容性套件亦为 `42 passed`。交付证据见
 | M2.1 Benchmark 注册与配置契约 | 已完成 | 受控 benchmark registry、config v2 和 schema；对应 `BENCH-01` | 配置只能选择已注册 benchmark，禁止任意 Python 导入；PR #6 双版本 45 项兼容性测试和 required gate 通过 |
 | M2.2 首个多路径缩减基准 | 已完成 | FourBranch reduced；对应 `BENCH-02` | 固定输入、seed、数据 hash、DoI 路径、manifest、trace、重复性测试和 PR #6 required gate 通过 |
 | M2.3 多问题 Benchmark 验收 | 已完成 | `BENCH-03`、`BENCH-04`、`BENCH-06` | FourBranch、Ishigami、Gayton 通过统一 schema、身份、contract hash、双版本测试和 required gate |
-| M3 包装、契约一致性与跨环境质量 | 待开始 | `PKG-*`、`CI-*`、`SCHEMA-*`、`MANIFEST-*` | wheel/sdist、版本源、运行时与发布 schema 一致、标准 schema 校验、完整来源/环境身份和支持平台 CI 达到发布门 |
+| M3 包装、契约一致性与跨环境质量 | 进行中 | `PKG-*`、`CI-*`、`SCHEMA-*`、`MANIFEST-*` | wheel/sdist、版本源、运行时与发布 schema 一致、标准 schema 校验、完整来源/环境身份和支持平台 CI 达到发布门 |
 | M4 受控论文生产接口与下游交付契约 | 待开始 | `PROD-*`、`DATA-*`、`CV-*`、`PROV-*`、`REL-*` | 论文仓库可通过版本化配置和冻结外部数据调用唯一 UQRA runner，并获得通过正式 schema 校验的 manifest、trace、来源环境身份和输入/输出哈希 |
 
 `LEG-*` 和 `REG-*` 属于 U1/U3 的证据闭环任务，不并入 M2 benchmark 交付，也不
@@ -234,8 +234,9 @@ manifest、Python 3.11/3.12 的 42 项兼容性测试、全新克隆验收、确
 已知限制均已进入 evidence package。论文项目是否拥有 FourBranch 等算例资产不
 阻塞 UQRA 通用功能发布，但不得用软件回归结果冒充论文算例复现。
 
-M2.3 已完成，证据见 `UQRA_M23_BENCHMARK_ACCEPTANCE.md`。下一最小目标转为
-**M3 包装、契约一致性与跨环境质量**；按顺序完成 M3 后再启动 M4 受控论文生产
+M2.3 已通过 PR #7（merge `1d3dacd`）完成，证据见
+`UQRA_M23_BENCHMARK_ACCEPTANCE.md`。**M3 包装、契约一致性与跨环境质量**已启动，
+当前执行 `SCHEMA-01` 与 `SCHEMA-02`；按顺序完成 M3 后再启动 M4 受控论文生产
 接口。新增正式发布必须使用新版本号，不得静默覆盖 `v0.2.0`。
 
 ## 7. 历史文档关系

--- a/specs/UQRA_PROJECT_PROGRESS_BOARD.md
+++ b/specs/UQRA_PROJECT_PROGRESS_BOARD.md
@@ -28,14 +28,14 @@
 | 项目 | 当前值 | 状态/证据 |
 | --- | --- | --- |
 | 默认分支 | `master` | ✅ `v0.2.0` 已发布 |
-| 当前工作分支 | `codex/complete-m23-benchmarks` | 🔄 M2.3 多问题 benchmark 验收 |
-| 最近 PR | [#7 Complete M2.3 multi-benchmark acceptance](https://github.com/Jinsongl/UQRA/pull/7) | 🔄 Draft；required CI 已通过 |
-| Python 3.11 | `52 passed` | ✅ [CI run 30980439387](https://github.com/Jinsongl/UQRA/actions/runs/30980439387) |
-| Python 3.12 | `52 passed` | ✅ [CI run 30980439387](https://github.com/Jinsongl/UQRA/actions/runs/30980439387) |
+| 当前工作分支 | `codex/schema-contract-validation` | 🔄 SCHEMA-01 + SCHEMA-02 |
+| 最近 PR | [#7 Complete M2.3 multi-benchmark acceptance](https://github.com/Jinsongl/UQRA/pull/7) | ✅ 已合并；merge `1d3dacd` |
+| Python 3.11 | `58 passed` | ✅ SCHEMA 本地完整 compatibility 验收 |
+| Python 3.12 | `58 passed` | ✅ SCHEMA 本地完整 compatibility 验收 |
 | Required check | `Adaptive compatibility gate` | ✅ 通过 |
 | 全新克隆验收 | Python 3.11.15，`42 passed`，smoke/full manifest 有效 | ✅ [`UQRA_V0.1.0_EVIDENCE.md`](releases/UQRA_V0.1.0_EVIDENCE.md) |
 | 当前 Release | [`v0.2.0`](https://github.com/Jinsongl/UQRA/releases/tag/v0.2.0) | ✅ 指向合并提交 `3445464d` |
-| 下一版本 | 待 M2.1--M2.3 完成范围确定 | ⏳ 不提前承诺版本号 |
+| 下一版本 | 待 M3 完成范围确定 | ⏳ 不提前承诺版本号 |
 
 ## 3. 编号体系与里程碑路线
 
@@ -50,7 +50,7 @@
 | M2.1 Benchmark 注册与配置契约 | ✅ 已完成 | U4、U6 | BENCH-01 | 静态 registry、config v2、双版本 45 项测试和 required gate 通过 |
 | M2.2 首个多路径缩减基准 | ✅ 已完成 | U4 | BENCH-02 | FourBranch reduced 的输入身份、DoI、trace、重复性和 PR #6 required gate 通过 |
 | M2.3 多问题 Benchmark 验收 | ✅ 已完成 | U4 | BENCH-03、BENCH-04、BENCH-06 | 三基准统一 contract hash 与双版本 `52 passed`；required gate 通过 |
-| M3 包装与跨环境质量 | ⏳ 待开始 | U6 | PKG-01--04、CI-01、SCHEMA-01 | 包装、版本源、schema 验证和跨平台 CI 达到发布门 |
+| M3 包装与跨环境质量 | 🔄 进行中 | U6 | PKG-01--04、CI-01、SCHEMA-01/02 | SCHEMA-01/02 已启动；包装、版本源、schema 验证和跨平台 CI 达到发布门 |
 
 `LEG-01/02` 与 `REG-01/02` 是 U1/U3 的证据闭环任务，不属于 M2，也不因 M2 完成
 而自动关闭。
@@ -85,7 +85,8 @@
 
 | ID | 归属 / 优先级 | 任务 | 当前证据 | 完成门 |
 | --- | --- | --- | --- | --- |
-当前无已启动的离散任务；下一主线为 M3，需单独启动后再移入本节。
+| SCHEMA-01 | M3 / P2 | 对齐 config v2、manifest 与 reduced benchmark 契约 | 发布 schema 已覆盖 config v1/v2、Phase 8 与三个 reduced benchmark；双版本 `58 passed` | required CI 通过并合并 |
+| SCHEMA-02 | M3 / P2 | 使用 Draft 2020-12 标准校验器验证 config/manifest/trace | 五个示例/benchmark 的生成产物已通过标准校验；错误 scenario 组合有拒绝测试 | required CI 通过并合并 |
 
 ### ⏳ 待开始
 
@@ -120,7 +121,6 @@
 | PKG-03 | M3 / P2 | 建立 `uqra.__version__` 唯一版本源 | 包、CLI、manifest 版本一致 |
 | PKG-04 | M3 / P2 | 清理 Python 3.12 转义警告 | 兼容性测试无对应 SyntaxWarning/DeprecationWarning |
 | CI-01 | M3 / P2 | 扩展 Windows/Linux CI | Python 3.11/3.12 在支持平台通过 |
-| SCHEMA-01 | M3 / P2 | 增加标准 JSON Schema 验证器测试 | 示例和生成 manifest 同时通过运行时与标准 schema 校验 |
 
 ### ⛔ 阻塞：历史资产
 

--- a/tests/compatibility/test_adaptive_runner.py
+++ b/tests/compatibility/test_adaptive_runner.py
@@ -2,6 +2,8 @@ import json
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
 
 from uqra.adaptive.benchmark_registry import benchmark_names, get_benchmark
 from uqra.adaptive.four_branch_reduced import INPUT_HASHES
@@ -52,6 +54,44 @@ def test_published_json_schemas_and_examples_are_well_formed():
     }
     for path, expected_schema in examples.items():
         assert load_config(path)["schema"] == expected_schema
+
+
+def _published_schema_validators():
+    names = [
+        "adaptive-runner-config.schema.json",
+        "adaptive-runner-config-v2.schema.json",
+        "adaptive-runner-manifest.schema.json",
+        "adaptive-trace.schema.json",
+    ]
+    schemas = {name: json.loads((ROOT / "schemas" / name).read_text(encoding="utf-8"))
+               for name in names}
+    registry = Registry().with_resources(
+        [(schema["$id"], Resource.from_contents(schema)) for schema in schemas.values()]
+    )
+    return {name: Draft202012Validator(schema, registry=registry)
+            for name, schema in schemas.items()}
+
+
+@pytest.mark.parametrize("path", [SMOKE_CONFIG, V2_SMOKE_CONFIG, FOUR_BRANCH_CONFIG,
+                                  ISHIGAMI_CONFIG, GAYTON_CONFIG])
+def test_examples_and_generated_artifacts_pass_published_draft202012_schemas(path):
+    validators = _published_schema_validators()
+    config = load_config(path)
+    config_schema = ("adaptive-runner-config.schema.json" if config["schema"] == CONFIG_SCHEMA
+                     else "adaptive-runner-config-v2.schema.json")
+    validators[config_schema].validate(config)
+    manifest = run_config(config)
+    validators["adaptive-runner-manifest.schema.json"].validate(manifest)
+    for scenario in manifest["run"]["scenarios"].values():
+        for row in scenario["trace"]:
+            validators["adaptive-trace.schema.json"].validate(row)
+
+
+def test_config_v2_schema_rejects_benchmark_scenario_mismatch():
+    validators = _published_schema_validators()
+    config = load_config(FOUR_BRANCH_CONFIG)
+    config["runner"]["scenarios"] = ["converged"]
+    assert list(validators["adaptive-runner-config-v2.schema.json"].iter_errors(config))
 
 
 def test_v2_schema_benchmark_enum_matches_static_registry():

--- a/uqra/adaptive/four_branch_reduced.py
+++ b/uqra/adaptive/four_branch_reduced.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from .controller import AdaptiveSparsePCE
 from .profiles import publication_profile
+from .reduced_fixture import contract_trace_hash
 from .state import array_hash
 
 
@@ -110,6 +111,7 @@ def run_scenario():
         "doi_center_test_ids": boundary_ids.tolist(),
         "trace_hash": result.trace_hash(),
         "trace_rows": len(result.trace),
+        "contract_trace_hash": contract_trace_hash(result.trace),
         "stage_counts": dict(sorted(stages.items())),
         "model_call_count": result.state.model_call_count,
         "evaluated_global_ids": list(result.state.evaluated_global_ids),
@@ -130,12 +132,20 @@ def run_suite(scenarios=None):
             "purpose": "software_benchmark",
             "scale": "reduced",
             "historical_replay": False,
+            "paper_production": False,
             "failure_definition": "min(g1,g2,g3,g4) <= 0",
             "cv_seed": CV_SEED,
             "datasets": _identity_payload(arrays),
         },
         "scenarios": {SCENARIO: run_scenario()},
     }
+    contract_manifest = json.loads(json.dumps(manifest, allow_nan=False))
+    for scenario in contract_manifest["scenarios"].values():
+        scenario.pop("trace", None)
+        scenario.pop("trace_hash", None)
+    manifest["contract_manifest_hash"] = hashlib.sha256(
+        json.dumps(contract_manifest, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    ).hexdigest()
     manifest["stable_manifest_hash"] = hashlib.sha256(
         json.dumps(manifest, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
     ).hexdigest()


### PR DESCRIPTION
## Summary

- align config v2 and runner manifest schemas with the Phase 8 and reduced benchmark contracts
- add Draft 2020-12 validation for config, manifest, and trace outputs
- migrate FourBranch reduced to the shared contract hash fields
- lock the schema validation dependencies for Python 3.11 and 3.12
- update the development plan and progress board to start SCHEMA-01 and SCHEMA-02

## Root cause

The published manifest schema still described only the original Phase 8/config v1 shape, while the current runner also emits config v2 and three reduced benchmark shapes. Existing tests exercised runtime behavior but did not validate generated artifacts with a standards-compliant JSON Schema validator.

## Validation

- Python 3.11 compatibility suite: 58 passed
- Python 3.12 compatibility suite: 58 passed
- targeted adaptive runner/schema suite: 20 passed
- `git diff --check`

## Acceptance

The remote `Adaptive compatibility gate` is the final acceptance gate for SCHEMA-01 and SCHEMA-02.